### PR TITLE
Change git:// to https:// for github

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -2,14 +2,14 @@
 <manifest>
   <default sync-j="8" revision="gatesgarth"/>
 
-  <remote name="digi" fetch="git://github.com/digi-embedded"/>
-  <remote name="fsl" fetch="git://github.com/Freescale"/>
+  <remote name="digi" fetch="https://github.com/digi-embedded"/>
+  <remote name="fsl" fetch="https://github.com/Freescale"/>
   <!-- <remote name="igl"   fetch="https://github.com/Igalia"/> -->
   <!-- <remote name="nxp"   fetch="git://source.codeaurora.org/external/imx"/> -->
-  <remote name="qt5" fetch="git://github.com/meta-qt5"/>
-  <remote name="swu" fetch="git://github.com/sbabic"/>
+  <remote name="qt5" fetch="https://github.com/meta-qt5"/>
+  <remote name="swu" fetch="https://github.com/sbabic"/>
   <remote name="oe" fetch="git://git.openembedded.org"/>
-  <remote name="yocto" fetch="git://git.yoctoproject.org"/>
+  <remote name="yocto" fetch="https://git.yoctoproject.org"/>
   <remote name="orbital" fetch="ssh://git@github.com"/>
 
   <project name="meta-digi.git"         path="sources/meta-digi"         remote="digi">


### PR DESCRIPTION
Due to auth and security github no longer supports git:// protocol.

Change-Id: I6b58a32132d32ad672850f93e5eb7e55326f0e21
