### PR TITLE
Change git:// to https:// for github

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -2,14 +2,14 @@
 <manifest>
   <default sync-j="8" revision="gatesgarth"/>
 
-  <remote name="digi" fetch="git://github.com/digi-embedded"/>
-  <remote name="fsl" fetch="git://github.com/Freescale"/>
+  <remote name="digi" fetch="https://github.com/digi-embedded"/>
+  <remote name="fsl" fetch="https://github.com/Freescale"/>
   <!-- <remote name="igl"   fetch="https://github.com/Igalia"/> -->
   <!-- <remote name="nxp"   fetch="git://source.codeaurora.org/external/imx"/> -->
-  <remote name="qt5" fetch="git://github.com/meta-qt5"/>
-  <remote name="swu" fetch="git://github.com/sbabic"/>
+  <remote name="qt5" fetch="https://github.com/meta-qt5"/>
+  <remote name="swu" fetch="https://github.com/sbabic"/>
   <remote name="oe" fetch="git://git.openembedded.org"/>
-  <remote name="yocto" fetch="git://git.yoctoproject.org"/>
+  <remote name="yocto" fetch="https://git.yoctoproject.org"/>
   <remote name="orbital" fetch="ssh://git@github.com"/>
 
   <project name="meta-digi.git"         path="sources/meta-digi"         remote="digi"  revision="9e68d61f7c465800d62913c044e43c541f2eacd7">

--- a/default.xml
+++ b/default.xml
@@ -12,20 +12,20 @@
   <remote name="yocto" fetch="git://git.yoctoproject.org"/>
   <remote name="orbital" fetch="ssh://git@github.com"/>
 
-  <project name="meta-digi.git"         path="sources/meta-digi"         remote="digi">
+  <project name="meta-digi.git"         path="sources/meta-digi"         remote="digi"  revision="9e68d61f7c465800d62913c044e43c541f2eacd7">
     <copyfile src="sdk/mkproject.sh" dest="mkproject.sh"/>
   </project>
   <!-- <project name="meta-digi-dualboot.git" path="sources/meta-digi-dualboot" remote="digi" /> -->
-  <project name="meta-freescale.git"    path="sources/meta-freescale"    remote="yocto" />
-  <project name="meta-fsl-demos.git"    path="sources/meta-fsl-demos"    remote="fsl" />
+  <project name="meta-freescale.git"    path="sources/meta-freescale"    remote="yocto" revision="d5a82541a97dd3a6b9116a1cd72f9965510a3de9" />
+  <project name="meta-fsl-demos.git"    path="sources/meta-fsl-demos"    remote="fsl"   revision="50eb2b32e7702bc435049bfe0a98fc65c864c106" />
   <!-- <project name="meta-imx.git" path="sources/meta-imx" remote="nxp" revision="gatesgarth-5.10.9-1.0.0"/> -->
-  <project name="meta-openembedded.git" path="sources/meta-openembedded" remote="oe" />
-  <project name="meta-python2.git"      path="sources/meta-python2"      remote="oe"/>
-  <project name="meta-qt5.git"          path="sources/meta-qt5"          remote="qt5" />
+  <project name="meta-openembedded.git" path="sources/meta-openembedded" remote="oe"    revision="f3f7a5f1a4713f145107bb043e0d14cb3a51c62f" />
+  <project name="meta-python2.git"      path="sources/meta-python2"      remote="oe"    revision="3fae17aece0e6d82f56965fe501bf7080c671df8"/>
+  <project name="meta-qt5.git"          path="sources/meta-qt5"          remote="qt5"   revision="2b33a5d5e888370bb56685b86aa82b73624f19f0" />
   <!-- <project name="meta-selinux.git" path="sources/meta-selinux" remote="yocto" /> -->
-  <project name="meta-swupdate.git"     path="sources/meta-swupdate"     remote="swu"/>
+  <project name="meta-swupdate.git"     path="sources/meta-swupdate"     remote="swu"   revision="744d6b96fc0290a7df9045e60c734c4924abfd4a"/>
   <!-- <project name="meta-webkit.git" path="sources/meta-webkit" remote="igl" /> -->
-  <project name="poky.git"              path="sources/poky"              remote="yocto" />
+  <project name="poky.git"              path="sources/poky"              remote="yocto" revision="bc71ec0f1d97c983cb0a089b15e283c56de30844" />
   <project name="orbital-systems/meta-orbital" path="sources/meta-orbital" remote="orbital">
     <copyfile src="sdk/setup.sh" dest="setup.sh"/>
   </project>


### PR DESCRIPTION
- Initial manifest for dey-2.4 (Rocko)
- Digi Embedded Yocto 2.4-r1.1
- Digi Embedded Yocto 2.4-r1.2
- dey-manifest: reset revisions to maintenance branches
- Digi Embedded Yocto 2.4-r2.3-beta
- dey-manifest: reset revisions to maintenance branches
- Digi Embedded Yocto 2.4-r2.4-beta
- dey-manifest: reset revisions to maintenance branches
- Digi Embedded Yocto dey-2.4-r2.2
- dey-manifest: reset revisions to maintenance branches
- Add meta-orbital
- Update to dey-2.6
- Copy setup.sh to root
- Update README for Orbital Systems
- Use our own meta-digi
- Use own version of swupdate
- fix typo
- default.xml: Pin all but meta-orbital to sha1
- Build latest version of Yocto Thud (2.6)
- Build latest version of Yocto Zeus (3.0)
- Build latest version of Yocto Gatesgarth (3.2)
- Change default branch to master
- default.xml: Pin all but meta-orbital to sha1
- Change git:// to https:// for github
