### PR TITLE
[OS-946] Fix meta-digi to dey-3.2-r2

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -12,7 +12,7 @@
   <remote name="yocto" fetch="https://git.yoctoproject.org"/>
   <remote name="orbital" fetch="ssh://git@github.com"/>
 
-  <project name="meta-digi.git"         path="sources/meta-digi"         remote="digi"  revision="d64f6455deeb68c44a042e82d780b18f36fc2113">
+  <project name="meta-digi.git"         path="sources/meta-digi"         remote="digi"  revision="44ff44680f0cbfaf143e963d7d3e64da275aa3b2">
     <copyfile src="sdk/mkproject.sh" dest="mkproject.sh"/>
   </project>
   <!-- <project name="meta-digi-dualboot.git" path="sources/meta-digi-dualboot" remote="digi" /> -->


### PR DESCRIPTION
This makes sure that all the recipes that meta-digi contains points to a fixed
git revision, and not autorev/master.

Change-Id: Ie79ad4b2e480a1da4f985fa41fce0c0d0bda20fe