### PR TITLE
[OS-947] Fix meta-digi to dey-3.2-r3

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -13,7 +13,7 @@
   <remote name="aws" fetch="https://github.com/aws"/>
   <remote name="orbital" fetch="ssh://git@github.com"/>
 
-  <project name="meta-digi.git"         path="sources/meta-digi"         remote="digi">
+  <project name="meta-digi.git"         path="sources/meta-digi"         remote="digi"  revision="9350358f5b0815971d2086d12524a9924a96cfd8">
     <copyfile src="sdk/mkproject.sh" dest="mkproject.sh"/>
   </project>
   <!-- <project name="meta-digi-dualboot.git" path="sources/meta-digi-dualboot" remote="digi" /> -->


### PR DESCRIPTION
This makes sure that all the recipes that meta-digi contains points to a fixed
git revision, and not autorev/master.

Change-Id: Ia294e53aaf98f6c56277b2ce3b5eb8d2c2a84940